### PR TITLE
:package: dependency 정리

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
   },
   "dependencies": {
     "color": "^3.1.3",
-    "lodash": "^4.17.21",
-    "react": "17.0.1",
-    "react-hook-form": "^7.8.4",
-    "react-native": "0.64.0",
     "react-native-actionsheet": "^2.4.2",
     "react-native-fast-image": "^8.3.4",
     "react-native-gesture-handler": "^1.10.3",
@@ -41,9 +37,7 @@
     "react-native-maps": "^0.28.0",
     "react-native-parsed-text": "^0.0.22",
     "react-native-rate": "^1.2.6",
-    "react-native-safe-area-context": "^3.2.0",
     "react-native-video": "^5.1.1",
-    "styled-components": "^5.3.0",
     "validate-color": "^2.1.1"
   },
   "devDependencies": {
@@ -86,11 +80,19 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-styled-components": "^7.0.4",
     "metro-react-native-babel-preset": "^0.64.0",
+    "react": "17.0.1",
     "react-dom": "^17.0.2",
+    "react-native": "0.64.0",
     "react-test-renderer": "17.0.1",
     "ts-jest": "^26.5.6",
     "typescript": "^4.1.4",
     "typescript-transform-paths": "^3.0.1"
+  },
+  "peerDependencies": {
+    "lodash": "^4.17.21",
+    "react-hook-form": "^7.8.4",
+    "react-native-safe-area-context": "^3.2.0",
+    "styled-components": "^5.3.0"
   },
   "resolutions": {
     "@types/react": "^17"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
     "react-native-parsed-text": "^0.0.22",
     "react-native-rate": "^1.2.6",
     "react-native-video": "^5.1.1",
-    "validate-color": "^2.1.1"
+    "validate-color": "^2.1.1",
+    "lodash": "^4.17.21",
+    "react-hook-form": "^7.8.4",
+    "react-native-safe-area-context": "^3.2.0",
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -87,12 +91,6 @@
     "ts-jest": "^26.5.6",
     "typescript": "^4.1.4",
     "typescript-transform-paths": "^3.0.1"
-  },
-  "peerDependencies": {
-    "lodash": "^4.17.21",
-    "react-hook-form": "^7.8.4",
-    "react-native-safe-area-context": "^3.2.0",
-    "styled-components": "^5.3.0"
   },
   "resolutions": {
     "@types/react": "^17"


### PR DESCRIPTION
RN Debugger 버그를 해결했습니다. dependency에 react-native가 있던 것이 문제였어서, devDependency로 옮겼습니다.